### PR TITLE
Fix 404 errors on calling `getTransactions(pair)`.

### DIFF
--- a/lib/publicApi.js
+++ b/lib/publicApi.js
@@ -41,13 +41,11 @@ BitbankccPublic.prototype.getDepth = function(pair) {
   return this.query(this.endPoint + path);
 };
 
-BitbankccPublic.prototype.getTransactions = function(pair) {
-  var path = "/" + pair + "/transactions";
-  return this.query(this.endPoint + path);
-};
-
 BitbankccPublic.prototype.getTransactions = function(pair, yyyymmdd) {
-  var path = "/" + pair + "/transactions/" + yyyymmdd;
+  var path = "/" + pair + "/transactions";
+  if (yyyymmdd !== undefined) {
+    path = path + "/" + yyyymmdd;
+  }
   return this.query(this.endPoint + path);
 };
 


### PR DESCRIPTION
Will fix #4.