### PR TITLE
Update version and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,10 @@ api2.requestWithdraw("btc", "uuid", 0.01, {"otp_token": 123456}).then(function(r
   console.log(res);
 });
 ```
+
+
+### trade history
+```
+api2.getTradeHistory().then(console.log);
+api2.getTradeHistory({ pair: "btc_jpy" }).then(console.log);
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-bitbankcc",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "bitbank.cc node.js library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The npm version is still `1.0.1` (without `api.getTradeHistory`), please `npm publish`.
https://www.npmjs.com/package/node-bitbankcc